### PR TITLE
[TT-17030] Migrate CLA workflow from PAT to GitHub App token

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,35 +1,41 @@
 name: "CLA Assistant"
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+          repositories: cla
+
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # Beta Release
-        uses: contributor-assistant/github-action@v2.2.0
+        uses: contributor-assistant/github-action@b2a7f9fb90217ea0b8a0c95c288221457be4a31f # v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN : ${{ secrets.ORG_GH_TOKEN}}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/TykTechnologies/tyk/blob/master/CLA.md'
-          # branch should not be protected
           branch: 'main'
-          ##people who don't have to sign the CLA comma separated e.g user1,user2
           allowlist: bot*
-          #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: 'TykTechnologies'
-          remote-repository-name:  cla
-          #create-file-commit-message: 'For example: Creating file for storing CLA Signatures'
-          #signed-commit-message: 'For example: $contributorName has signed the CLA in #$pullRequestNo'
-          #custom-notsigned-prcomment: 'pull request comment with Introductory message to ask new contributors to sign'
-          #custom-pr-sign-comment: 'The signature to be committed in order to sign the CLA'
-          #custom-allsigned-prcomment: 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          remote-repository-name: cla
           lock-pullrequest-aftermerge: true
-


### PR DESCRIPTION
## Summary

- Replace `ORG_GH_TOKEN` (personal access token) with a short-lived token generated from the probelabs GitHub App via `actions/create-github-app-token`
- The generated token is scoped to only the `TykTechnologies/cla` repository, following the principle of least privilege
- SHA-pin both `actions/create-github-app-token` and `contributor-assistant/github-action` for supply chain security
- Add explicit `permissions` block (`contents: write`, `pull-requests: write`, `actions: read`)

## Why

Personal access tokens (PATs) are long-lived, broadly scoped, and tied to individual user accounts. GitHub App tokens are short-lived (1 hour), scoped to specific repositories, and not tied to any individual user.

This pattern has already been tested and verified on [TykTechnologies/opentelemetry](https://github.com/TykTechnologies/opentelemetry).

## Test plan

- [ ] Verify the CLA workflow runs successfully on a test PR
- [ ] Verify the `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` organization secrets are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)